### PR TITLE
Enable to filter output by -f option

### DIFF
--- a/lltsv.go
+++ b/lltsv.go
@@ -25,13 +25,25 @@ func newLltsv(keys []string, no_key bool) *Lltsv {
 	}
 }
 
-func (lltsv *Lltsv) scanAndWrite(file *os.File) error {
+func (lltsv *Lltsv) scanAndWrite(file *os.File, filters map[string]Filter) error {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
 		lvs := lltsv.parseLtsv(line)
-		ltsv := lltsv.restructLtsv(lvs)
-		os.Stdout.WriteString(ltsv + "\n")
+
+		should_output := true
+
+		for key, filter := range filters {
+			if !filter(lvs[key]) {
+				should_output = false
+				break
+			}
+		}
+
+		if should_output {
+			ltsv := lltsv.restructLtsv(lvs)
+			os.Stdout.WriteString(ltsv + "\n")
+		}
 	}
 	return scanner.Err()
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"log"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/codegangsta/cli"
@@ -9,6 +12,8 @@ import (
 
 // os.Exit forcely kills process, so let me share this global variable to terminate at the last
 var exitCode = 0
+
+type Filter func(string) bool
 
 func main() {
 	app := cli.NewApp()
@@ -31,6 +36,16 @@ func main() {
 
 	Specify input files as arguments.
 
+	Example4 $ lltsv -k resptime,status,uri -f 'resptime > 6' access_log
+	         $ lltsv -k resptime,status,uri -f 'resptime > 6' -f 'uri =~ ^/foo' access_log
+
+	Filter output with "-f" option. Available comparing operaters are:
+
+	  >= > == < <= (arithmetic (float64))
+	  =~ !~        (regular expression (string))
+
+	You can specify multiple -f options (AND condition).
+
 	Homepage: https://github.com/sonots/lltsv`
 	app.Author = "sonots"
 	app.Email = "sonots@gmail.com"
@@ -42,6 +57,10 @@ func main() {
 		cli.BoolFlag{
 			Name:  "no-key, K",
 			Usage: "output without keys (and without color)",
+		},
+		cli.StringSliceFlag{
+			Name:  "filter, f",
+			Usage: "filter expression to output",
 		},
 	}
 	app.Action = doMain
@@ -56,6 +75,54 @@ func doMain(c *cli.Context) {
 	}
 	no_key := c.Bool("no-key")
 
+	filters := map[string]Filter{}
+
+	for _, f := range c.StringSlice("filter") {
+		token := strings.SplitN(f, " ", 3)
+		key := token[0]
+		switch token[1] {
+		case ">", ">=", "==", "<=", "<":
+			r, err := strconv.ParseFloat(token[2], 64)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			filters[key] = func(val string) bool {
+				num, err := strconv.ParseFloat(val, 64)
+				if err != nil {
+					log.Println(err)
+					return false
+				}
+				switch token[1] {
+				case ">":
+					return num > r
+				case ">=":
+					return num >= r
+				case "==":
+					return num == r
+				case "<=":
+					return num <= r
+				case "<":
+					return num < r
+				default:
+					return false
+				}
+			}
+		case "=~", "!~":
+			re := regexp.MustCompile(token[2])
+			filters[key] = func(val string) bool {
+				switch token[1] {
+				case "=~":
+					return re.MatchString(val)
+				case "!~":
+					return !re.MatchString(val)
+				default:
+					return false
+				}
+			}
+		}
+	}
+
 	lltsv := newLltsv(keys, no_key)
 
 	if len(c.Args()) > 0 {
@@ -66,7 +133,7 @@ func doMain(c *cli.Context) {
 				exitCode = 1
 				return
 			}
-			err = lltsv.scanAndWrite(file)
+			err = lltsv.scanAndWrite(file, filters)
 			file.Close()
 			if err != nil {
 				os.Stderr.WriteString("reading input errored\n")
@@ -76,7 +143,7 @@ func doMain(c *cli.Context) {
 		}
 	} else {
 		file := os.Stdin
-		err := lltsv.scanAndWrite(file)
+		err := lltsv.scanAndWrite(file, filters)
 		file.Close()
 		if err != nil {
 			os.Stderr.WriteString("reading input errored\n")


### PR DESCRIPTION
Add feature to filter output with -f option.

```
$ sample_ltsv() { printf "reqtime:1\tstatus:200\turi:/foo\nreqtime:2\tstatus:200\turi:/bar\nreqtime:3\tstatus:500\turi:/baz\n"; }

$ sample_ltsv | ./lltsv -k reqtime,status,uri
reqtime:1       status:200      uri:/foo
reqtime:2       status:200      uri:/bar
reqtime:3       status:500      uri:/baz

$ sample_ltsv | ./lltsv -k reqtime,status,uri -f 'reqtime <= 2'
reqtime:1       status:200      uri:/foo
reqtime:2       status:200      uri:/bar
```

We can specify multiple -f options, in this case filters are AND condition.

```
$ sample_ltsv | ./lltsv -k reqtime,status,uri -f 'reqtime <= 2' -f 'uri =~ ^/ba'
reqtime:2       status:200      uri:/bar
```
## Performance issue
- no -f option: slow a little bit
- with -f option (match all): slow 0.5sec (103% against original lltsv v0.3.1)
- with -f option (filtered 27%): fast!!

```
$ wc -l sample_access_log
721968 sample_access_log

### lltsv version 0.3.1
$ time lltsv sample_access_log >/dev/null
real    0m9.699s
user    0m9.614s
sys     0m0.445s

### lltsv this PR, without -f option
$ time ./lltsv sample_access_log >/dev/null
real    0m9.752s
user    0m9.603s
sys     0m0.509s

### lltsv this PR, with -f option (match all)
$ time ./lltsv -f 'reqtime >= 0' sample_access_log >/dev/null
real    0m10.055s
user    0m9.962s
sys     0m0.458s

### lltsv this PR, with -f option (filtered 27%)
$ time ./lltsv -f 'reqtime >= 3' sample_access_log >/dev/null
real    0m8.770s
user    0m8.734s
sys     0m0.353s

$ ./lltsv -f 'reqtime >= 3' sample_access_log | wc -l
527202 (filtered 27%)
```
