### PR TITLE
filter: fixed panic error when the invalid filter expression is given.

### DIFF
--- a/lltsv.go
+++ b/lltsv.go
@@ -115,6 +115,10 @@ func getFuncFilters(filters []string) map[string]tFuncFilter {
 	funcFilters := map[string]tFuncFilter{}
 	for _, f := range filters {
 		token := strings.SplitN(f, " ", 3)
+		if len(token) < 3 {
+			log.Printf("filter expression is invalid: %s\n", f)
+			continue
+		}
 		key := token[0]
 		switch token[1] {
 		case ">", ">=", "==", "<=", "<":


### PR DESCRIPTION
## Before

```
$ cat access_log | lltsv -f '.'
panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x1a8220, 0xc8200100b0)
        /Users/bokko/go/src/runtime/panic.go:481 +0x3e6
main.getFuncFilters(0xc8200743e0, 0x2, 0x2, 0x1)
        /Users/bokko/.go/src/github.com/sonots/lltsv/lltsv.go:119 +0x7ea
main.newLltsv(0xc820074760, 0x2, 0x2, 0x0, 0xc8200743e0, 0x2, 0x2, 0xebf9a)
        /Users/bokko/.go/src/github.com/sonots/lltsv/lltsv.go:32 +0x50
main.doMain(0xc8200b4140)
        /Users/bokko/.go/src/github.com/sonots/lltsv/main.go:74 +0x31f
github.com/codegangsta/cli.(*App).Run(0xc8200b4000, 0xc820072070, 0x7, 0x7, 0x0, 0x0)
        /Users/bokko/.go/src/github.com/codegangsta/cli/app.go:192 +0x117d
main.main()
        /Users/bokko/.go/src/github.com/sonots/lltsv/main.go:62 +0x3b8
```
## After

```
$ cat access_log | lltsv -f '.'
2016/06/11 23:18:36 filter expression is invalid: .
...
```
