### PR TITLE
Introduced new option: -expr, -e.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ Filter output with "-f" option. Available comparing operaters are:
 
 You can specify multiple -f options (AND condition).
 
+Example5:
+
+```bash
+$ lltsv -k resptime,upstream_resptime,diff -f 'diff = resptime - upstream_resptime' access_log
+```
+
+Evaluate value with "-e" option. Available operaters are:
+
+```
+  + - * / (arithmetic (float64))
+```
+
 **How Useful?**
 
 LTSV format is not `awk` friendly (I think), but `lltsv` can help it: 

--- a/lltsv.go
+++ b/lltsv.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"log"
 	"os"
 	"regexp"
@@ -14,22 +15,33 @@ import (
 
 type tFuncAppend func([]string, string, string) []string
 type tFuncFilter func(string) bool
+type tFuncExpr func(string, string) string
+
+type ExprRunner struct {
+	f  tFuncExpr
+	ol string
+	or string
+}
 
 type Lltsv struct {
 	keys        []string
 	no_key      bool
 	filters     []string
+	exprs       []string
 	funcAppend  tFuncAppend
 	funcFilters map[string]tFuncFilter
+	funcExprs   map[string]*ExprRunner
 }
 
-func newLltsv(keys []string, no_key bool, filters []string) *Lltsv {
+func newLltsv(keys []string, no_key bool, filters []string, exprs []string) *Lltsv {
 	return &Lltsv{
 		keys:        keys,
 		no_key:      no_key,
 		filters:     filters,
+		exprs:       exprs,
 		funcAppend:  getFuncAppend(no_key),
 		funcFilters: getFuncFilters(filters),
+		funcExprs:   getFuncExprs(exprs),
 	}
 }
 
@@ -38,11 +50,13 @@ func (lltsv *Lltsv) scanAndWrite(file *os.File) error {
 	for scanner.Scan() {
 		line := scanner.Text()
 		lvs := lltsv.parseLtsv(line)
+		lltsv.expr(lvs)
 
 		if lltsv.filter(lvs) {
 			ltsv := lltsv.restructLtsv(lvs)
 			os.Stdout.WriteString(ltsv + "\n")
 		}
+
 	}
 	return scanner.Err()
 }
@@ -58,6 +72,16 @@ func (lltsv *Lltsv) filter(lvs map[string]string) bool {
 	}
 
 	return should_output
+}
+
+func (lltsv *Lltsv) expr(lvs map[string]string) {
+	for key, funcExpr := range lltsv.funcExprs {
+		l, ok1 := lvs[funcExpr.ol]
+		r, ok2 := lvs[funcExpr.or]
+		if ok1 && ok2 {
+			lvs[key] = funcExpr.f(l, r)
+		}
+	}
 }
 
 // lvs: label and value pairs
@@ -109,6 +133,63 @@ func getFuncAppend(no_key bool) tFuncAppend {
 			}
 		}
 	}
+}
+
+func getFuncExprs(exprs []string) map[string]*ExprRunner {
+	funcExprs := make(map[string]*ExprRunner, len(exprs))
+	for _, f := range exprs {
+		token := strings.SplitN(f, " ", 5)
+		if len(token) < 5 {
+			log.Printf("expression is invalid: %s\n", f)
+			continue
+		}
+
+		key := token[0]
+
+		if token[1] != "=" {
+			log.Printf("expression is invalid: %s\n", f)
+			continue
+		}
+
+		operator := token[3]
+		switch operator {
+		case "+", "-", "*", "/":
+			// pass through
+		default:
+			log.Printf("expression is invalid: %s\n", f)
+			continue
+		}
+
+		funcExprs[key] = &ExprRunner{
+			f: func(ls, rs string) string {
+				l, err := strconv.ParseFloat(ls, 64)
+				if err != nil {
+					return ""
+				}
+				r, err := strconv.ParseFloat(rs, 64)
+				if err != nil {
+					return ""
+				}
+				result := float64(0)
+				switch operator {
+				case "+":
+					result = l + r
+				case "-":
+					result = l - r
+				case "*":
+					result = l * r
+				case "/":
+					result = l / r
+				default:
+					return ""
+				}
+				return fmt.Sprintf("%.3f", result)
+			},
+			ol: token[2],
+			or: token[4],
+		}
+	}
+	return funcExprs
 }
 
 func getFuncFilters(filters []string) map[string]tFuncFilter {

--- a/main.go
+++ b/main.go
@@ -41,6 +41,12 @@ func main() {
 
 	You can specify multiple -f options (AND condition).
 
+	Example5 $ lltsv -k resptime,upstream_resptime,diff -f 'diff = resptime - upstream_resptime' access_log
+
+	Evaluate value with "-e" option. Available operaters are:
+
+	  + - * / (arithmetic (float64))
+
 	Homepage: https://github.com/sonots/lltsv`
 	app.Author = "sonots"
 	app.Email = "sonots@gmail.com"
@@ -57,6 +63,10 @@ func main() {
 			Name:  "filter, f",
 			Usage: "filter expression to output",
 		},
+		cli.StringSliceFlag{
+			Name:  "expr, e",
+			Usage: "evaluate value by expression to output",
+		},
 	}
 	app.Action = doMain
 	app.Run(os.Args)
@@ -70,8 +80,9 @@ func doMain(c *cli.Context) {
 	}
 	no_key := c.Bool("no-key")
 	filters := c.StringSlice("filter")
+	exprs := c.StringSlice("expr")
 
-	lltsv := newLltsv(keys, no_key, filters)
+	lltsv := newLltsv(keys, no_key, filters, exprs)
 
 	if len(c.Args()) > 0 {
 		for _, filename := range c.Args() {


### PR DESCRIPTION
Given '**result = operator1** _operand_ **operator2**' to -expr, the value of **result** in ltsv is orverwritten.

Available operaters are:

```
+ - * / (arithmetic (float64))
```

For example, this feature is useful for calculating difference between response time and response time from upstream server. In nginx, **$request_time** and **$upstream_response_time** is available.

``` nginx
# nginx.conf
log_format ltsv 'time:$time_local\t'
                'uri:$uri\t'
                'status:$status\t'
                'ua:$http_user_agent\t'
                'resptime:$request_time\t'
                'upstream_resptime:$upstream_response_time\t';
```

``` console
$ tail -f /var/log/nginx/access.log | lltsv -k uri,resptime,upstream_resptime,diff -e 'diff = resptime - upstream_resptime' -f 'diff > 0.05'
uri:/hoge  resptime:0.120     upstream_resptime:0.050    diff:0.070
uri:/foo     resptime:0.110     upstream_resptime:0.030    diff:0.080
```
