### PR TITLE
feature: enabled perfect string match by '=='.

### DIFF
--- a/lltsv.go
+++ b/lltsv.go
@@ -202,7 +202,7 @@ func getFuncFilters(filters []string) map[string]tFuncFilter {
 		}
 		key := token[0]
 		switch token[1] {
-		case ">", ">=", "==", "<=", "<":
+		case ">", ">=", "<=", "<":
 			r, err := strconv.ParseFloat(token[2], 64)
 			if err != nil {
 				log.Fatal(err)
@@ -219,8 +219,6 @@ func getFuncFilters(filters []string) map[string]tFuncFilter {
 					return num > r
 				case ">=":
 					return num >= r
-				case "==":
-					return num == r
 				case "<=":
 					return num <= r
 				case "<":
@@ -228,6 +226,10 @@ func getFuncFilters(filters []string) map[string]tFuncFilter {
 				default:
 					return false
 				}
+			}
+		case "==":
+			funcFilters[key] = func(val string) bool {
+				return val == token[2]
 			}
 		case "=~", "!~":
 			re := regexp.MustCompile(token[2])


### PR DESCRIPTION
Previously **==** was used for only a comparison between numbers.
## Before

```
$ tail -f /var/log/nginx/access.log  | lltsv -k uri,status -f 'status == 200' -f 'uri == /mypage/'
2016/10/28 19:19:43 strconv.ParseFloat: parsing "/mypage/": invalid syntax
```
## After

```
$ $ tail -f /var/log/nginx/access.log  | lltsv -k uri,status -f 'status == 200' -f 'uri == /mypage/'
uri:/mypage/        status:200
uri:/mypage/        status:200
```
