### PR TITLE
filter: exited when invalid filter expression was given.

### DIFF
--- a/lltsv.go
+++ b/lltsv.go
@@ -197,8 +197,7 @@ func getFuncFilters(filters []string) map[string]tFuncFilter {
 	for _, f := range filters {
 		token := strings.SplitN(f, " ", 3)
 		if len(token) < 3 {
-			log.Printf("filter expression is invalid: %s\n", f)
-			continue
+			log.Fatalf("filter expression is invalid: %s\n", f)
 		}
 		key := token[0]
 		switch token[1] {


### PR DESCRIPTION
Previously, lltsv continued processing after outputting such as the error message below even if invalid filter expression was given.

```
2016/11/24 10:08:08 filter expression is invalid: requesttime>0.5
```

But it is possible to miss an error message when many ltsv lines are processed. Because an error message is output only on startup.