### PR TITLE
expr: re-implemented by go package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Example5:
 
 ```bash
 $ lltsv -k resptime,upstream_resptime,diff -e 'diff = resptime - upstream_resptime' access_log
+$ lltsv -k resptime,upstream_resptime,diff_ms -e 'diff_ms = (resptime - upstream_resptime) * 1000' access_log
 ```
 
 Evaluate value with "-e" option. Available operators are:

--- a/eval.go
+++ b/eval.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"go/ast"
+	"go/constant"
+	"go/parser"
+	"strconv"
+)
+
+type ExprRunner struct {
+	expr ast.Expr
+}
+
+type Vars map[string]string
+
+type ExprContext struct {
+	vars Vars
+}
+
+func parseExpr(e string) (ast.Expr, error) {
+	expr, err := parser.ParseExpr(e)
+	if err != nil {
+		return nil, err
+	}
+
+	return expr, nil
+}
+
+func evalExpr(expr ast.Expr, ctx *ExprContext) (constant.Value, error) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		return evalBasicLit(e, ctx)
+	case *ast.BinaryExpr:
+		return evalBinaryExpr(e, ctx)
+	case *ast.Ident:
+		return evalIdent(e, ctx)
+	case *ast.ParenExpr:
+		return evalExpr(e.X, ctx)
+	}
+
+	return constant.MakeUnknown(), errors.New("unknown expr")
+}
+
+func evalBasicLit(expr *ast.BasicLit, ctx *ExprContext) (constant.Value, error) {
+	return constant.MakeFromLiteral(expr.Value, expr.Kind, 0), nil
+}
+
+func evalBinaryExpr(expr *ast.BinaryExpr, ctx *ExprContext) (constant.Value, error) {
+	x, err := evalExpr(expr.X, ctx)
+	if err != nil {
+		return constant.MakeUnknown(), err
+	}
+
+	y, err := evalExpr(expr.Y, ctx)
+	if err != nil {
+		return constant.MakeUnknown(), err
+	}
+
+	return constant.BinaryOp(x, expr.Op, y), nil
+}
+
+func evalIdent(expr *ast.Ident, ctx *ExprContext) (constant.Value, error) {
+	name, ok := ctx.vars[expr.Name]
+	if !ok {
+		return constant.MakeUnknown(), errors.New("unknown variable name")
+	}
+
+	n, err := strconv.ParseFloat(name, 64)
+	if err != nil {
+		return constant.MakeUnknown(), errors.New("variable type must be numeric")
+	}
+
+	return constant.MakeFloat64(n), nil
+}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	You can specify multiple -f options (AND condition).
 
 	Example5 $ lltsv -k resptime,upstream_resptime,diff -f 'diff = resptime - upstream_resptime' access_log
+	         $ lltsv -k resptime,upstream_resptime,diff_ms -e 'diff_ms = (resptime - upstream_resptime) * 1000' access_log
 
 	Evaluate value with "-e" option. Available operators are:
 


### PR DESCRIPTION
More complicated expressions such as below are available.

```
diff = (ptime - uptime) * 1000
```

```bash
$ cat sample.ltsv
uri:/hoge       ptime:0.120     uptime:0.050
uri:/foo        ptime:0.110     uptime:0.030
$ cat sample.ltsv | lltsv -k uri,ptime,uptime,diff_ms -e 'diff_ms = (ptime - uptime) * 1000'
uri:/hoge       ptime:0.120     uptime:0.050    diff_ms:70
uri:/foo        ptime:0.110     uptime:0.030    diff_ms:80
```
