### PR TITLE
0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0 (2017/04/11)
+
+Fixes:
+
+* sort keys by default. refs: #16
+* build: fixed `go get` error for ghr. refs #15
+
 ## 0.5.6 (2017/03/21)
 
 Fixes:

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version string = "0.5.6"
+const Version string = "0.6.0"


### PR DESCRIPTION
As #16 changes default behavior, it is required to update major version.