### PR TITLE
feature: introduced --ignore-key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ COMMANDS:
 GLOBAL OPTIONS:
    --key, -k                                            keys to output (multiple keys separated by ,)
    --no-key, -K                                         output without keys (and without color)
+   --ignore-key value, -i value                         ignored keys to output (multiple keys separated by ,)
    --filter, -f [--filter option --filter option]       filter expression to output
    --expr, -e [--expr option --expr option]             evaluate value by expression to output
    --help, -h                                           show help

--- a/lltsv.go
+++ b/lltsv.go
@@ -16,14 +16,14 @@ type tFuncAppend func([]string, string, string) []string
 type tFuncFilter func(string) bool
 
 type Lltsv struct {
-	keys        []string
+	keys         []string
 	ignoreKeyMap map[string]struct{}
-	no_key      bool
-	filters     []string
-	exprs       []string
-	funcAppend  tFuncAppend
-	funcFilters map[string]tFuncFilter
-	exprRunners map[string]*ExprRunner
+	no_key       bool
+	filters      []string
+	exprs        []string
+	funcAppend   tFuncAppend
+	funcFilters  map[string]tFuncFilter
+	exprRunners  map[string]*ExprRunner
 }
 
 func newLltsv(keys []string, ignoreKeys []string, no_key bool, filters []string, exprs []string) *Lltsv {
@@ -32,14 +32,14 @@ func newLltsv(keys []string, ignoreKeys []string, no_key bool, filters []string,
 		ignoreKeyMap[key] = struct{}{}
 	}
 	return &Lltsv{
-		keys:        keys,
+		keys:         keys,
 		ignoreKeyMap: ignoreKeyMap,
-		no_key:      no_key,
-		filters:     filters,
-		exprs:       exprs,
-		funcAppend:  getFuncAppend(no_key),
-		funcFilters: getFuncFilters(filters),
-		exprRunners: getExprRunners(exprs),
+		no_key:       no_key,
+		filters:      filters,
+		exprs:        exprs,
+		funcAppend:   getFuncAppend(no_key),
+		funcFilters:  getFuncFilters(filters),
+		exprRunners:  getExprRunners(exprs),
 	}
 }
 

--- a/lltsv.go
+++ b/lltsv.go
@@ -17,6 +17,7 @@ type tFuncFilter func(string) bool
 
 type Lltsv struct {
 	keys        []string
+	ignoreKeyMap map[string]struct{}
 	no_key      bool
 	filters     []string
 	exprs       []string
@@ -25,9 +26,14 @@ type Lltsv struct {
 	exprRunners map[string]*ExprRunner
 }
 
-func newLltsv(keys []string, no_key bool, filters []string, exprs []string) *Lltsv {
+func newLltsv(keys []string, ignoreKeys []string, no_key bool, filters []string, exprs []string) *Lltsv {
+	ignoreKeyMap := make(map[string]struct{})
+	for _, key := range ignoreKeys {
+		ignoreKeyMap[key] = struct{}{}
+	}
 	return &Lltsv{
 		keys:        keys,
+		ignoreKeyMap: ignoreKeyMap,
 		no_key:      no_key,
 		filters:     filters,
 		exprs:       exprs,
@@ -89,6 +95,9 @@ func (lltsv *Lltsv) restructLtsv(lvs map[string]string, keys []string) string {
 	// cf. http://golang.org/pkg/builtin/#append
 	selected := make([]string, 0, len(orders))
 	for _, label := range orders {
+		if _, ok := lltsv.ignoreKeyMap[label]; ok {
+			continue
+		}
 		value := lvs[label]
 		selected = lltsv.funcAppend(selected, label, value)
 	}

--- a/main.go
+++ b/main.go
@@ -63,6 +63,10 @@ func main() {
 			Name:  "no-key, K",
 			Usage: "output without keys (and without color)",
 		},
+		cli.StringFlag{
+			Name:  "ignore-key, i",
+			Usage: "ignored keys to output (multiple keys separated by ,)",
+		},
 		cli.StringSliceFlag{
 			Name:  "filter, f",
 			Usage: "filter expression to output",
@@ -86,7 +90,13 @@ func doMain(c *cli.Context) error {
 	filters := c.StringSlice("filter")
 	exprs := c.StringSlice("expr")
 
-	lltsv := newLltsv(keys, no_key, filters, exprs)
+	ignoreKeys := make([]string, 0, 0)
+	// If -k,--key is specified, -i,--ignore-key is ignored.
+	if len(keys) == 0 && c.String("ignore-key") != "" {
+		ignoreKeys = strings.Split(c.String("ignore-key"), ",")
+	}
+
+	lltsv := newLltsv(keys, ignoreKeys, no_key, filters, exprs)
 
 	if len(c.Args()) > 0 {
 		for _, filename := range c.Args() {


### PR DESCRIPTION
Specifies ignored keys to output. If **-k,--keys** is specified, this option is ignored.

```
$ cat sample.ltsv
uri:/hoge       ptime:0.120     uptime:0.050
uri:/foo          ptime:0.110     uptime:0.030
$ lltsv -i uptime sample.ltsv
uri:/hoge       ptime:0.120
uri:/foo          ptime:0.110
$ lltsv -k uri,ptime,uptime -i uptime sample.ltsv
uri:/hoge       ptime:0.120     uptime:0.050
uri:/foo        ptime:0.110     uptime:0.030
```