### PR TITLE
feature: add time grep option: --timegrep, -t.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ Evaluate value with "-e" option. Available operators are:
   + - * / (arithmetic (float64))
 ```
 
+Grep period in common log format(common log or ISO 8610) "-t" option. Available operators are:
+
+Example6:
+
+```bash
+$ lltsv -t 'localtime=01/Jun/2018:00:00:00 +0900~30/Mar/2018:23:59:59 +0900,common' access_log
+$ lltsv -t 'localtime=2018-01-01T00:00:00+0900~2018-03-30T23:59:59+0900,iso8610' access_log
+```
+
 **How Useful?**
 
 LTSV format is not `awk` friendly (I think), but `lltsv` can help it: 

--- a/main.go
+++ b/main.go
@@ -53,6 +53,11 @@ func main() {
 
 	  + - * / (arithmetic (float64))
 
+	Grep period in common log format(common log or ISO 8610) "-t" option. Available operators are:
+
+	Example6 $ lltsv -t 'localtime=01/Jun/2018:00:00:00 +0900~30/Mar/2018:23:59:59 +0900,common' access_log
+	         $ lltsv -t 'localtime=2018-01-01T00:00:00+0900~2018-03-30T23:59:59+0900,iso8610' access_log
+
 	Homepage: https://github.com/sonots/lltsv`
 	app.Author = "sonots"
 	app.Email = "sonots@gmail.com"
@@ -76,6 +81,10 @@ func main() {
 		cli.StringSliceFlag{
 			Name:  "expr, e",
 			Usage: "evaluate value by expression to output",
+		},
+		cli.StringSliceFlag{
+			Name:  "timegrep, t",
+			Usage: "grep period of time in common log format or iso8601",
 		},
 	}
 	app.Action = doMain
@@ -102,6 +111,7 @@ func doMain(c *cli.Context) error {
 	noKey := c.Bool("no-key")
 	filters := c.StringSlice("filter")
 	exprs := c.StringSlice("expr")
+	timegrep := c.StringSlice("timegrep")
 
 	ignoreKeys := make([]string, 0, 0)
 	// If -k,--key is specified, -i,--ignore-key is ignored.
@@ -109,7 +119,7 @@ func doMain(c *cli.Context) error {
 		ignoreKeys = strings.Split(c.String("ignore-key"), ",")
 	}
 
-	lltsv := newLltsv(keys, ignoreKeys, noKey, filters, exprs)
+	lltsv := newLltsv(keys, ignoreKeys, noKey, filters, exprs, timegrep)
 
 	if len(c.Args()) > 0 {
 		for _, filename := range c.Args() {


### PR DESCRIPTION
For grep intuitively any period of time in log, add new option "-t" 
it supports between common log format and ISO8601
usage:

- common log format
```
$cat access_common.log
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:14:44 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:14:45 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:14:46 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:14:47 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:14:48 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:15:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:16:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:02:17:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:03:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:05:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:09:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:14:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:16/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:16/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:16/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:17/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:18/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:19/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502


$./lltsv -t 'localtime=15/Jun/2018:03:00:00 +0900~16/Jun/2018:05:00:00 +0900,common' access_common.log
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:03:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:05:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:09:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:15/Jun/2018:14:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:16/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:16/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:16/Jun/2018:04:14:43 +0900    arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
```
- iso8601

```
$cat access_iso8601.log
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:14:44+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:14:45+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:14:46+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:14:47+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:14:48+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:15:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:16:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T02:17:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T03:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T05:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T09:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T14:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-16T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-16T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-16T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-17T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-18T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-19T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502


$./lltsv -t 'localtime=2018-06-15T03:00:00+0900~2018-06-16T05:00:00+0900,iso8601' access_iso8601.log
remote:127.0.0.1        host:example.jp localtime:2018-06-15T03:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T05:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T09:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-15T14:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-16T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-16T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
remote:127.0.0.1        host:example.jp localtime:2018-06-16T04:14:43+0900      arrival_time:1528996483.783   method:GET      path:/test.html version:HTTP/1.1        code:502
```
